### PR TITLE
Lowercase template argument

### DIFF
--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ Description:        Child theme for use with FoundationPress
 Version:            1.0.0
 Author:             Dave Naylor
 Author URI:         http://davenaylor.me.uk
-Template:           FoundationPress
+Template:           foundationpress
 License:            MIT License
 License URI:        http://www.opensource.org/licenses/mit-license.php
 */


### PR DESCRIPTION
There seems to be an issue on some production sites, such as wpengine, in
reading camel-cased template names. Going off of the codex, it is demonstrated
that template is lowercase. We should do the same.